### PR TITLE
Fix "Won't work if the game is not launched from the Launcher"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 - `readme.txt`
     - bothersome to maintain, has no formatting. Replaced with html version
+    
+### Fixed
+- Won't work if the game is not launched from the Launcher (e.g. when launching from the EXE files in the bin\ subdirectory)
+    - See https://github.com/EngineOfDarkness/Stalker-Anomaly-Ltx-Loader/issues/8
 
 ## [0.2.0] - 2021-03-17
 ### Added

--- a/gamedata/scripts/autoloader.script
+++ b/gamedata/scripts/autoloader.script
@@ -12,6 +12,9 @@
     
 --]]
 
+-- register Anomaly root folder as package path so that launching from Launcher or exe files in the bin\ subdirectory doesn't create problems with relative require paths
+package.path = package.path .. string.format("%s?.lua;", getFS():update_path("$fs_root$", ""))
+
 local FileLoader = require "gamedata\\scripts\\config\\FileLoader"
 
 function register()


### PR DESCRIPTION
Closes #8 

----

I've added the Anomaly Root Folder to `package.path` so this should not cause any issues in the future (unless upper / lowercase turns out to be a problem on some systems - I hope not)

I've simply used Xrays `getFS` class to get the current Anomaly root via `update_path("$fs_root$", "")`